### PR TITLE
Generate inline tables for column groups

### DIFF
--- a/d2txt.py
+++ b/d2txt.py
@@ -811,7 +811,7 @@ def pack_colgroup_table(
         value = toml_row.get(column_name)
         if value is not None:
             member_values[member_alias] = value
-    return member_values if len(member_values) > 1 else None
+    return member_values if member_values else None
 
 
 def make_toml_row(

--- a/d2txt.py
+++ b/d2txt.py
@@ -353,21 +353,22 @@ def range_1(stop: int) -> range:
 
 
 def make_colgroup(
-    seq: Iterable[Union[int, str]], colgroup: str, columns: Iterable[str]
-) -> Dict[str, List[str]]:
-    """Generates a parametrized column group using a sequence of values."""
-    return {
-        colgroup.format(param): [col.format(param) for col in columns] for param in seq
-    }
+    params: Iterable[Union[int, str]], colgroup: str, columns: Iterable[str]
+) -> List[Tuple[str, Tuple[str, ...]]]:
+    """Generates column groups by using formatting parameters."""
+    return [
+        (colgroup.format(param), tuple(col.format(param) for col in columns))
+        for param in params
+    ]
 
 
 def initialize_column_groups(
-    colgroups: Mapping[str, Sequence[str]]
+    *colgroups: Sequence[Tuple[str, Sequence[str]]]
 ) -> List[Tuple[str, Tuple[str, ...]]]:
     """Initializes the list of column groups.
 
     Args:
-        colgroups: Maps each column group alias to its member columns.
+        colgroups: Tuples of the form (group alias, sequence of member columns).
 
     Returns:
         List of tuples containing column groups. Each tuple is of the form
@@ -375,7 +376,7 @@ def initialize_column_groups(
         The list is sorted by # of member columns, from greatest to least.
     """
     return sorted(
-        ((alias, tuple(members)) for alias, members in colgroups.items()),
+        ((alias, tuple(members)) for alias, members in colgroups),
         key=lambda colgroup: len(colgroup[1]),
         reverse=True,
     )
@@ -451,150 +452,150 @@ _DIFFICULTY_BASED_COLUMNS = [
     "MaxHP",
 ]
 
-# Mapping of group alias => list of column names
+# List of column group definitions
 # pylint: disable=line-too-long
 # fmt: off
-COLUMN_GROUPS = initialize_column_groups({
+COLUMN_GROUPS = initialize_column_groups(
     # Armor.txt, Misc.txt, Weapons.txt
-    "--MinMaxAC": ["MinAC", "MaxAC"],
-    **make_colgroup(range_1(3), "--StatAndCalc{}", ["stat{}", "calc{}"]),
-    "--MinMaxDam": ["MinDam", "MaxDam"],
-    "--2HandMinMaxDam": ["2HandMinDam", "2HandMaxDam"],
-    "--MinMaxMisDam": ["MinMisDam", "MaxMisDam"],
-    "--MinMaxStack": ["MinStack", "MaxStack"],
-    **make_colgroup(_VENDORS, "--{}MinMax", ["{}Min", "{}Max"]),
-    **make_colgroup(_VENDORS, "--{}MagicMinMax", ["{}MagicMin", "{}MagicMax"]),
-    "--NormUberUltraCode": ["NormCode", "UberCode", "UltraCode"],
-    "--wClass1And2Handed": ["wClass", "2HandedWClass"],
-    "--InvWidthHeight": ["InvWidth", "InvHeight"],
-    "--NightmareAndHellUpgrades": ["NightmareUpgrade", "HellUpgrade"],
+    ("--MinMaxAC", ("MinAC", "MaxAC")),
+    *make_colgroup(range_1(3), "--StatAndCalc{}", ["stat{}", "calc{}"]),
+    ("--MinMaxDam", ("MinDam", "MaxDam")),
+    ("--2HandMinMaxDam", ("2HandMinDam", "2HandMaxDam")),
+    ("--MinMaxMisDam", ("MinMisDam", "MaxMisDam")),
+    ("--MinMaxStack", ("MinStack", "MaxStack")),
+    *make_colgroup(_VENDORS, "--{}MinMax", ["{}Min", "{}Max"]),
+    *make_colgroup(_VENDORS, "--{}MagicMinMax", ["{}MagicMin", "{}MagicMax"]),
+    ("--NormUberUltraCode", ("NormCode", "UberCode", "UltraCode")),
+    ("--wClass1And2Handed", ("wClass", "2HandedWClass")),
+    ("--InvWidthHeight", ("InvWidth", "InvHeight")),
+    ("--NightmareAndHellUpgrades", ("NightmareUpgrade", "HellUpgrade")),
     # AutoMagic.txt, MagicPrefix.txt, MagicSuffix.txt
-    **make_colgroup(range_1(3), "--Mod{}MinMax", ["Mod{}Min", "Mod{}Max"]),
-    "--IType1-7": [f"IType{i}" for i in range_1(7)],
-    "--EType1-3": [f"EType{i}" for i in range_1(3)],
-    "--EType1-5": [f"EType{i}" for i in range_1(5)],  # For MagicPrefix.txt
-    "--DivideMultiplyAdd": ["Divide", "Multiply", "Add"],
+    *make_colgroup(range_1(3), "--Mod{}MinMax", ["Mod{}Min", "Mod{}Max"]),
+    ("--IType1-7", tuple(f"IType{i}" for i in range_1(7))),
+    ("--EType1-3", tuple(f"EType{i}" for i in range_1(3))),
+    ("--EType1-5", tuple(f"EType{i}" for i in range_1(5))),  # For MagicPrefix.txt
+    ("--DivideMultiplyAdd", ("Divide", "Multiply", "Add")),
     # CharStats.txt
-    **make_colgroup(range_1(10), "--ItemLocCount{}", ["Item{}", "Item{}Loc", "Item{}Count"]),
+    *make_colgroup(range_1(10), "--ItemLocCount{}", ["Item{}", "Item{}Loc", "Item{}Count"]),
     # CubeMain.txt
-    **make_colgroup(range_1(5), "--Mod-{}-MinMax", ["mod {} min", "mod {} max"]),
-    **make_colgroup(range_1(5), "--B-Mod-{}-MinMax", ["b mod {} min", "b mod {} max"]),
-    **make_colgroup(range_1(5), "--C-Mod-{}-MinMax", ["c mod {} min", "c mod {} max"]),
+    *make_colgroup(range_1(5), "--Mod-{}-MinMax", ["mod {} min", "mod {} max"]),
+    *make_colgroup(range_1(5), "--B-Mod-{}-MinMax", ["b mod {} min", "b mod {} max"]),
+    *make_colgroup(range_1(5), "--C-Mod-{}-MinMax", ["c mod {} min", "c mod {} max"]),
     # Gems.txt
-    **make_colgroup(range_1(3), "--WeaponMod{}MinMax", ["WeaponMod{}Min", "WeaponMod{}Max"]),
-    **make_colgroup(range_1(3), "--HelmMod{}MinMax", ["HelmMod{}Min", "HelmMod{}Max"]),
-    **make_colgroup(range_1(3), "--ShieldMod{}MinMax", ["ShieldMod{}Min", "ShieldMod{}Max"]),
+    *make_colgroup(range_1(3), "--WeaponMod{}MinMax", ["WeaponMod{}Min", "WeaponMod{}Max"]),
+    *make_colgroup(range_1(3), "--HelmMod{}MinMax", ["HelmMod{}Min", "HelmMod{}Max"]),
+    *make_colgroup(range_1(3), "--ShieldMod{}MinMax", ["ShieldMod{}Min", "ShieldMod{}Max"]),
     # Hireling.txt
-    "--NameFirstAndLast": ["NameFirst", "NameLast"],
-    **make_colgroup(["HP", "Str", "Dex", "AR", "Resist"], "--{}-/Lvl", ["{}", "{}/Lvl"]),
-    "--Defense-/Lvl": ["Defense", "Def/Lvl"],
-    "--Dmg-MinMax-/Lvl": ["Dmg-Min", "Dmg-Max", "Dmg/Lvl"],
-    **make_colgroup(range_1(6), "--Chance{}-PerLvl", ["Chance{}", "ChancePerLvl{}"]),
-    **make_colgroup(range_1(6), "--Level{}-PerLvl", ["Level{}", "LvlPerLvl{}"]),
+    ("--NameFirstAndLast", ("NameFirst", "NameLast")),
+    *make_colgroup(["HP", "Str", "Dex", "AR", "Resist"], "--{}-/Lvl", ["{}", "{}/Lvl"]),
+    ("--Defense-/Lvl", ("Defense", "Def/Lvl")),
+    ("--Dmg-MinMax-/Lvl", ("Dmg-Min", "Dmg-Max", "Dmg/Lvl")),
+    *make_colgroup(range_1(6), "--Chance{}-PerLvl", ["Chance{}", "ChancePerLvl{}"]),
+    *make_colgroup(range_1(6), "--Level{}-PerLvl", ["Level{}", "LvlPerLvl{}"]),
     # Inventory.txt
-    **make_colgroup(["Inv", "Grid", "rArm", "Torso"], "--{}LeftRightTopBottom", ["{}Left", "{}Right", "{}Top", "{}Bottom"]),
-    "--GridXY": ["GridX", "GridY"],
-    "--GridBoxWidthHeight": ["GridBoxWidth", "GridBoxHeight"],
-    **make_colgroup(
+    *make_colgroup(["Inv", "Grid", "rArm", "Torso"], "--{}LeftRightTopBottom", ["{}Left", "{}Right", "{}Top", "{}Bottom"]),
+    ("--GridXY", ("GridX", "GridY")),
+    ("--GridBoxWidthHeight", ("GridBoxWidth", "GridBoxHeight")),
+    *make_colgroup(
         ["rArm", "Torso", "lArm", "Head", "Neck", "rHand", "lHand", "Belt", "Feet", "Gloves"],
         "--{}LeftRightTopBottomWidthHeight",
         ["{}Left", "{}Right", "{}Top", "{}Bottom", "{}Width", "{}Height"]
     ),
     # ItemTypes.txt
-    "--BodyLoc1-2": ["BodyLoc1", "BodyLoc2"],
-    "--MaxSock1-25-40": ["MaxSock1", "MaxSock25", "MaxSock40"],
+    ("--BodyLoc1-2", ("BodyLoc1", "BodyLoc2")),
+    ("--MaxSock1-25-40", ("MaxSock1", "MaxSock25", "MaxSock40")),
     # Levels.txt
-    **make_colgroup(["", "(N)", "(H)"], "--SizeXY{}", ["SizeX{}", "SizeY{}"]),
-    "--OffsetXY": ["OffsetX", "OffsetY"],
-    **make_colgroup(range(8), "--VizAndWarp{}", ["Vis{}", "Warp{}"]),
-    "--MonLvl-123": ["MonLvl1", "MonLvl2", "MonLvl3"],
-    "--MonLvlEx-123": ["MonLvl1Ex", "MonLvl2Ex", "MonLvl3Ex"],
-    "--MonDen-RNH": ["MonDen", "MonDen(N)", "MonDen(H)"],
-    **make_colgroup(["", "(N)", "(H)"], "--MonUMinMax{}", ["MonUMin{}", "MonUMax{}"]),
-    **make_colgroup(range(8), "--ObjGrpAndPrb{}", ["ObjGrp{}", "ObjPrb{}"]),
+    *make_colgroup(["", "(N)", "(H)"], "--SizeXY{}", ["SizeX{}", "SizeY{}"]),
+    ("--OffsetXY", ("OffsetX", "OffsetY")),
+    *make_colgroup(range(8), "--VizAndWarp{}", ["Vis{}", "Warp{}"]),
+    ("--MonLvl-123", ("MonLvl1", "MonLvl2", "MonLvl3")),
+    ("--MonLvlEx-123", ("MonLvl1Ex", "MonLvl2Ex", "MonLvl3Ex")),
+    ("--MonDen-RNH", ("MonDen", "MonDen(N)", "MonDen(H)")),
+    *make_colgroup(["", "(N)", "(H)"], "--MonUMinMax{}", ["MonUMin{}", "MonUMax{}"]),
+    *make_colgroup(range(8), "--ObjGrpAndPrb{}", ["ObjGrp{}", "ObjPrb{}"]),
     # LvlMaze.txt
-    "--Rooms-RNH": ["Rooms", "Rooms(N)", "Rooms(H)"],
-    # "--SizeXY": ["SizeX", "SizeY"],  # Also in Levels.txt
+    ("--Rooms-RNH", ("Rooms", "Rooms(N)", "Rooms(H)")),
+    # ("--SizeXY", ("SizeX", "SizeY")),  # Also in Levels.txt
     # LvlPrest.txt
-    # "--SizeXY": ["SizeX", "SizeY"],  # Also in Levels.txt
+    # ("--SizeXY", ("SizeX", "SizeY")),  # Also in Levels.txt
     # Missiles.txt
-    "--pSrvCltDoFunc": ["pSrvDoFunc", "pCltDoFunc"],
-    "--pSrvCltHitFunc": ["pSrvHitFunc", "pCltHitFunc"],
-    **make_colgroup(range_1(3), "--SrvCltSubMissile{}", ["SubMissile{}", "CltSubMissile{}"]),
-    **make_colgroup(range_1(4), "--SrvCltHitSubMissile{}", ["HitSubMissile{}", "CltHitSubMissile{}"]),
-    **make_colgroup(range_1(5), "--ParamAndDesc{}", ["Param{}", "*param{} desc"]),
-    **make_colgroup(range_1(5), "--CltParamAndDesc{}", ["CltParam{}", "*client param{} desc"]),
-    **make_colgroup(range_1(3), "--sHitParAndDesc{}", ["sHitPar{}", "*server hit param{} desc"]),
-    **make_colgroup(range_1(3), "--cHitParAndDesc{}", ["cHitPar{}", "*client hit param{} desc"]),
-    **make_colgroup(range_1(2), "--dParamAndDesc{}", ["dParam{}", "*damage param{} desc"]),
-    "--MinDamage0-5": ["MinDamage", "MinLevDam1", "MinLevDam2", "MinLevDam3", "MinLevDam4", "MinLevDam5"],
-    "--MaxDamage0-5": ["MaxDamage", "MaxLevDam1", "MaxLevDam2", "MaxLevDam3", "MaxLevDam4", "MaxLevDam5"],
-    "--MinE0-5": ["EMin", "MinELev1", "MinELev2", "MinELev3", "MinELev4", "MinELev5"],
-    "--MaxE0-5": ["EMax", "MaxELev1", "MaxELev2", "MaxELev3", "MaxELev4", "MaxELev5"],
-    "--ELen0-3": ["ELen", "ELevLen1", "ELevLen2", "ELevLen3"],
-    "--RedGreenBlue": ["Red", "Green", "Blue"],
+    ("--pSrvCltDoFunc", ("pSrvDoFunc", "pCltDoFunc")),
+    ("--pSrvCltHitFunc", ("pSrvHitFunc", "pCltHitFunc")),
+    *make_colgroup(range_1(3), "--SrvCltSubMissile{}", ["SubMissile{}", "CltSubMissile{}"]),
+    *make_colgroup(range_1(4), "--SrvCltHitSubMissile{}", ["HitSubMissile{}", "CltHitSubMissile{}"]),
+    *make_colgroup(range_1(5), "--ParamAndDesc{}", ["Param{}", "*param{} desc"]),
+    *make_colgroup(range_1(5), "--CltParamAndDesc{}", ["CltParam{}", "*client param{} desc"]),
+    *make_colgroup(range_1(3), "--sHitParAndDesc{}", ["sHitPar{}", "*server hit param{} desc"]),
+    *make_colgroup(range_1(3), "--cHitParAndDesc{}", ["cHitPar{}", "*client hit param{} desc"]),
+    *make_colgroup(range_1(2), "--dParamAndDesc{}", ["dParam{}", "*damage param{} desc"]),
+    ("--MinDamage0-5", ("MinDamage", "MinLevDam1", "MinLevDam2", "MinLevDam3", "MinLevDam4", "MinLevDam5")),
+    ("--MaxDamage0-5", ("MaxDamage", "MaxLevDam1", "MaxLevDam2", "MaxLevDam3", "MaxLevDam4", "MaxLevDam5")),
+    ("--MinE0-5", ("EMin", "MinELev1", "MinELev2", "MinELev3", "MinELev4", "MinELev5")),
+    ("--MaxE0-5", ("EMax", "MaxELev1", "MaxELev2", "MaxELev3", "MaxELev4", "MaxELev5")),
+    ("--ELen0-3", ("ELen", "ELevLen1", "ELevLen2", "ELevLen3")),
+    ("--RedGreenBlue", ("Red", "Green", "Blue")),
     # MonProp.txt
-    **make_colgroup(range_1(6), "--MinMax{}", ["Min{}", "Max{}"]),
-    **make_colgroup(range_1(6), "--MinMax{} (N)", ["Min{} (N)", "Max{} (N)"]),
-    **make_colgroup(range_1(6), "--MinMax{} (H)", ["Min{} (H)", "Max{} (H)"]),
+    *make_colgroup(range_1(6), "--MinMax{}", ["Min{}", "Max{}"]),
+    *make_colgroup(range_1(6), "--MinMax{} (N)", ["Min{} (N)", "Max{} (N)"]),
+    *make_colgroup(range_1(6), "--MinMax{} (H)", ["Min{} (H)", "Max{} (H)"]),
     # MonStats.txt
-    "--MinMaxGrp": ["MinGrp", "MaxGrp"],
-    **make_colgroup(_DIFFICULTY_BASED_COLUMNS, "--{}-RNH", ["{}", "{}(N)", "{}(H)"]),
+    ("--MinMaxGrp", ("MinGrp", "MaxGrp")),
+    *make_colgroup(_DIFFICULTY_BASED_COLUMNS, "--{}-RNH", ["{}", "{}(N)", "{}(H)"]),
     # MonStats2.txt
-    # "--SizeXY": ["SizeX", "SizeY"],  # Also in Levels.txt
-    "--Light-RGB": ["Light-R", "Light-G", "Light-B"],
-    "--uTrans-RNH": ["uTrans", "uTrans(N)", "uTrans(H)"],
-    "--htTopLeftWidthHeight": ["htTop", "htLeft", "htWidth", "htHeight"],
+    # ("--SizeXY", ("SizeX", "SizeY")),  # Also in Levels.txt
+    ("--Light-RGB", ("Light-R", "Light-G", "Light-B")),
+    ("--uTrans-RNH", ("uTrans", "uTrans(N)", "uTrans(H)")),
+    ("--htTopLeftWidthHeight", ("htTop", "htLeft", "htWidth", "htHeight")),
     # Objects.txt
-    **make_colgroup(["Size", "nTgtF", "nTgtB"], "--{}XY", ["{}X", "{}Y"]),
-    **make_colgroup(["Offset", "Space"], "--XY{}", ["X{}", "Y{}"]),
-    "--LeftTopWidthHeight": ["Left", "Top", "Width", "Height"],
+    *make_colgroup(["Size", "nTgtF", "nTgtB"], "--{}XY", ["{}X", "{}Y"]),
+    *make_colgroup(["Offset", "Space"], "--XY{}", ["X{}", "Y{}"]),
+    ("--LeftTopWidthHeight", ("Left", "Top", "Width", "Height")),
     # Overlay.txt
-    # "--XYOffset": ["xOffset", "yOffset"],  # Also in Objects.txt
-    # "--RedGreenBlue": ["Red", "Green", "Blue"],  # Also in Missiles.txt
+    # ("--XYOffset", ("xOffset", "yOffset")),  # Also in Objects.txt
+    # ("--RedGreenBlue", ("Red", "Green", "Blue")),  # Also in Missiles.txt
     # Runes.txt
-    "--IType1-6": [f"IType{i}" for i in range_1(6)],
-    # "--EType1-3": [f"IType{i}" for i in range_1(3)],  # Also in AutoMagic.txt
-    "--Rune1-6": [f"Rune{i}" for i in range_1(6)],
-    **make_colgroup(range_1(6), "--T1MinMax{}", ["T1Min{}", "T1Max{}"]),
+    ("--IType1-6", tuple(f"IType{i}" for i in range_1(6))),
+    # ("--EType1-3", tuple(f"IType{i}" for i in range_1(3))),  # Also in AutoMagic.txt
+    ("--Rune1-6", tuple(f"Rune{i}" for i in range_1(6))),
+    *make_colgroup(range_1(6), "--T1MinMax{}", ["T1Min{}", "T1Max{}"]),
     # Sets.txt
-    **make_colgroup(range(1, 6), "--pMinMax{}A", ["pMin{}A", "pMax{}A"]),
-    **make_colgroup(range(1, 6), "--pMinMax{}B", ["pMin{}B", "pMax{}B"]),
-    **make_colgroup(range_1(8), "--fMinMax{}", ["fMin{}", "fMax{}"]),
+    *make_colgroup(range(1, 6), "--pMinMax{}A", ["pMin{}A", "pMax{}A"]),
+    *make_colgroup(range(1, 6), "--pMinMax{}B", ["pMin{}B", "pMax{}B"]),
+    *make_colgroup(range_1(8), "--fMinMax{}", ["fMin{}", "fMax{}"]),
     # SetItems.txt
-    **make_colgroup(range_1(9), "--MinMax{}", ["Min{}", "Max{}"]),
-    **make_colgroup(range_1(5), "--aMinMaxA{}", ["aMin{}A", "aMax{}A"]),
-    **make_colgroup(range_1(5), "--aMinMaxB{}", ["aMin{}A", "aMax{}B"]),
+    *make_colgroup(range_1(9), "--MinMax{}", ["Min{}", "Max{}"]),
+    *make_colgroup(range_1(5), "--aMinMaxA{}", ["aMin{}A", "aMax{}A"]),
+    *make_colgroup(range_1(5), "--aMinMaxB{}", ["aMin{}A", "aMax{}B"]),
     # Skills.txt
-    "--SrvCltStFunc": ["SrvStFunc", "CltStFunc"],
-    "--SrvCltDoFunc": ["SrvDoFunc", "CltDoFunc"],
-    "--SrvCltMissile": ["SrvMissile", "CltMissile"],
-    **make_colgroup(["", "A", "B", "C"], "--SrvCltMissile{}", ["SrvMissile{}", "CltMissile{}"]),
-    **make_colgroup(range_1(6), "--AuraStatAndCalc{}", ["AuraStat{}", "AuraStatCalc{}"]),
-    **make_colgroup(range_1(6), "--PassiveStatAndCalc{}", ["PassiveStat{}", "PassiveCalc{}"]),
-    **make_colgroup(range_1(3), "--AuraEventAndFunc{}", ["AuraEvent{}", "AuraEventFunc{}"]),
-    "--AuraTgtEventAndFunc": ["AuraTgtEvent", "AuraTgtEventFunc"],
-    "--PassiveEventAndFunc": ["PassiveEvent", "PassiveEventFunc"],
-    **make_colgroup(range_1(8), "--ParamAndDescription{}", ["Param{}", "*Param{} Description"]),
-    "--MinDam0-5": ["MinDam", "MinLevDam1", "MinLevDam2", "MinLevDam3", "MinLevDam4", "MinLevDam5"],
-    "--MaxDam0-5": ["MaxDam", "MaxLevDam1", "MaxLevDam2", "MaxLevDam3", "MaxLevDam4", "MaxLevDam5"],
-    "--EMin0-5": ["EMin", "EMinLev1", "EMinLev2", "EMinLev3", "EMinLev4", "EMinLev5"],
-    "--EMax0-5": ["EMax", "EMaxLev1", "EMaxLev2", "EMaxLev3", "EMaxLev4", "EMaxLev5"],
-    # "--ELen0-3": ["ELen", "ELevLen1", "ELevLen2", "ELevLen3"],  # Also in Skills.txt
-    "--CostMultAdd": ["cost mult", "cost add"],
+    ("--SrvCltStFunc", ("SrvStFunc", "CltStFunc")),
+    ("--SrvCltDoFunc", ("SrvDoFunc", "CltDoFunc")),
+    ("--SrvCltMissile", ("SrvMissile", "CltMissile")),
+    *make_colgroup(["", "A", "B", "C"], "--SrvCltMissile{}", ["SrvMissile{}", "CltMissile{}"]),
+    *make_colgroup(range_1(6), "--AuraStatAndCalc{}", ["AuraStat{}", "AuraStatCalc{}"]),
+    *make_colgroup(range_1(6), "--PassiveStatAndCalc{}", ["PassiveStat{}", "PassiveCalc{}"]),
+    *make_colgroup(range_1(3), "--AuraEventAndFunc{}", ["AuraEvent{}", "AuraEventFunc{}"]),
+    ("--AuraTgtEventAndFunc", ("AuraTgtEvent", "AuraTgtEventFunc")),
+    ("--PassiveEventAndFunc", ("PassiveEvent", "PassiveEventFunc")),
+    *make_colgroup(range_1(8), "--ParamAndDescription{}", ["Param{}", "*Param{} Description"]),
+    ("--MinDam0-5", ("MinDam", "MinLevDam1", "MinLevDam2", "MinLevDam3", "MinLevDam4", "MinLevDam5")),
+    ("--MaxDam0-5", ("MaxDam", "MaxLevDam1", "MaxLevDam2", "MaxLevDam3", "MaxLevDam4", "MaxLevDam5")),
+    ("--EMin0-5", ("EMin", "EMinLev1", "EMinLev2", "EMinLev3", "EMinLev4", "EMinLev5")),
+    ("--EMax0-5", ("EMax", "EMaxLev1", "EMaxLev2", "EMaxLev3", "EMaxLev4", "EMaxLev5")),
+    # ("--ELen0-3", ("ELen", "ELevLen1", "ELevLen2", "ELevLen3")),  # Also in Skills.txt
+    ("--CostMultAdd", ("cost mult", "cost add")),
     # SkillDesc.txt
-    "--SkillPageRowColumn": ["SkillPage", "SkillRow", "SkillColumn"],
+    ("--SkillPageRowColumn", ("SkillPage", "SkillRow", "SkillColumn")),
     # States.txt
-    # "--Light-RGB": ["Light-R", "Light-G", "Light-B"],  # Also in MonStats2.txt
+    # ("--Light-RGB", ("Light-R", "Light-G", "Light-B")),  # Also in MonStats2.txt
     # SuperUniques.txt
-    # "--MinMaxGrp": ["MinGrp", "MaxGrp"],  # Also in MonStats.txt
-    # "--uTrans-RNH": ["uTrans", "uTrans(N)", "uTrans(H)"],  # Also in MonStats2.txt
+    # ("--MinMaxGrp", ("MinGrp", "MaxGrp")),  # Also in MonStats.txt
+    # ("--uTrans-RNH", ("uTrans", "uTrans(N)", "uTrans(H)")),  # Also in MonStats2.txt
     # TreasureClassEx.txt
-    **make_colgroup(range_1(10), "--ProbAndItem{}", ["Prob{}", "Item{}"]),
+    *make_colgroup(range_1(10), "--ProbAndItem{}", ["Prob{}", "Item{}"]),
     # UniqueItems.txt
-    **make_colgroup(range_1(12), "--MinMax{}", ["Min{}", "Max{}"]),
-    # "--CostMultAdd": ["cost mult", "cost add"],  # Also in Skills.txt
-})
+    *make_colgroup(range_1(12), "--MinMax{}", ["Min{}", "Max{}"]),
+    # ("--CostMultAdd", ("cost mult", "cost add")),  # Also in Skills.txt
+)
 # fmt: on
 # pylint: enable=line-too-long
 

--- a/d2txt.py
+++ b/d2txt.py
@@ -451,99 +451,61 @@ _VENDORS = [
     "Ormus",
 ]
 
-# Columns with one variation per difficulty in MonStats.txt
-_DIFFICULTY_BASED_COLUMNS = [
-    "Level",
-    "AIDel",
-    "AIDist",
-    "aip1",
-    "aip2",
-    "aip3",
-    "aip4",
-    "aip5",
-    "aip6",
-    "aip7",
-    "aip8",
-    "Drain",
-    "ColdEffect",
-    "ResDm",
-    "ResMa",
-    "ResFi",
-    "ResLi",
-    "ResCo",
-    "ResPo",
-    "ToBlock",
-    "AC",
-    "Exp",
-    "A1MinD",
-    "A1MaxD",
-    "A1TH",
-    "A2MinD",
-    "A2MaxD",
-    "A2TH",
-    "S1MinD",
-    "S1MaxD",
-    "S1TH",
-    "El1Pct",
-    "El1MinD",
-    "El1MaxD",
-    "El1Dur",
-    "El2Pct",
-    "El2MinD",
-    "El2MaxD",
-    "El2Dur",
-    "El3Pct",
-    "El3MinD",
-    "El3MaxD",
-    "El3Dur",
-    "MinHP",
-    "MaxHP",
-]
-
 # List of column group definitions
 # pylint: disable=line-too-long
 # fmt: off
 COLUMN_GROUPS = initialize_column_groups(
     # Armor.txt, Misc.txt, Weapons.txt
-    ("--MinMaxAC", ("MinAC", "MaxAC")),
-    *make_colgroup(range_1(3), "--StatAndCalc{}", ["stat{}", "calc{}"]),
-    ("--MinMaxDam", ("MinDam", "MaxDam")),
-    ("--2HandMinMaxDam", ("2HandMinDam", "2HandMaxDam")),
-    ("--MinMaxMisDam", ("MinMisDam", "MaxMisDam")),
-    ("--MinMaxStack", ("MinStack", "MaxStack")),
-    *make_colgroup(_VENDORS, "--{}MinMax", ["{}Min", "{}Max"]),
-    *make_colgroup(_VENDORS, "--{}MagicMinMax", ["{}MagicMin", "{}MagicMax"]),
-    ("--NormUberUltraCode", ("NormCode", "UberCode", "UltraCode")),
-    ("--wClass1And2Handed", ("wClass", "2HandedWClass")),
-    ("--InvWidthHeight", ("InvWidth", "InvHeight")),
-    ("--NightmareAndHellUpgrades", ("NightmareUpgrade", "HellUpgrade")),
+    ("__AC", {"min": "MinAC", "max": "MaxAC"}),
+    *make_colgroup(range_1(3), "__Stat{}", {"stat": "stat{}", "calc": "calc{}"}),
+    ("__Damage", {"min": "MinDam", "max": "MaxDam"}),
+    ("__2HandDam", {"min": "2HandMinDam", "max": "2HandMaxDam"}),
+    ("__MisDam", {"min": "MinMisDam", "max": "MaxMisDam"}),
+    ("__Stack", {"min": "MinStack", "max": "MaxStack"}),
+    *make_colgroup(
+        _VENDORS,
+        "__{}MinMax",
+        {"Min": "{}Min", "Max": "{}Max", "MagicMin": "{}MagicMin", "MagicMax": "{}MagicMax", "MagicLvl": "{}MagicLvl"},
+    ),
+    ("__Code", {"normal": "NormCode", "uber": "UberCode", "ultra": "UltraCode"}),
+    ("__wClass", {"1hand": "wClass", "2hand": "2HandedWClass"}),
+    ("__Inv", {"width": "InvWidth", "height": "InvHeight"}),
+    ("__Upgrades", {"nightmare": "NightmareUpgrade", "hell": "HellUpgrade"}),
     # AutoMagic.txt, MagicPrefix.txt, MagicSuffix.txt
-    *make_colgroup(range_1(3), "--Mod{}MinMax", ["Mod{}Min", "Mod{}Max"]),
+    *make_colgroup(range_1(3), "__Mod{}", {"prop": "Mod{}Code", "param": "Mod{}Param", "min": "Mod{}Min", "max": "Mod{}Max"}),
     ("--IType1-7", tuple(f"IType{i}" for i in range_1(7))),
     ("--EType1-3", tuple(f"EType{i}" for i in range_1(3))),
     ("--EType1-5", tuple(f"EType{i}" for i in range_1(5))),  # For MagicPrefix.txt
-    ("--DivideMultiplyAdd", ("Divide", "Multiply", "Add")),
+    ("__Cost", {"divide": "Divide", "multiply": "Multiply", "add": "Add"}),
     # CharStats.txt
-    *make_colgroup(range_1(10), "--ItemLocCount{}", ["Item{}", "Item{}Loc", "Item{}Count"]),
+    *make_colgroup(range_1(10), "__Item{}", {"code": "Item{}", "loc": "Item{}Loc", "count": "Item{}Count"}),
     # CubeMain.txt
-    *make_colgroup(range_1(5), "--Mod-{}-MinMax", ["mod {} min", "mod {} max"]),
-    *make_colgroup(range_1(5), "--B-Mod-{}-MinMax", ["b mod {} min", "b mod {} max"]),
-    *make_colgroup(range_1(5), "--C-Mod-{}-MinMax", ["c mod {} min", "c mod {} max"]),
+    *make_colgroup(range_1(5), "__Mod{}", {"mod": "mod {}", "chance": "mod {} chance", "param": "mod {} param", "min": "mod {} min", "max": "mod {} max"}),
+    *make_colgroup(range_1(5), "__B_Mod{}", {"mod": "b mod {}", "chance": "b mod {} chance", "param": "b mod {} param", "min": "b mod {} min", "max": "b mod {} max"}),
+    *make_colgroup(range_1(5), "__C_Mod{}", {"mod": "c mod {}", "chance": "c mod {} chance", "param": "c mod {} param", "min": "c mod {} min", "max": "c mod {} max"}),
     # Gems.txt
-    *make_colgroup(range_1(3), "--WeaponMod{}MinMax", ["WeaponMod{}Min", "WeaponMod{}Max"]),
-    *make_colgroup(range_1(3), "--HelmMod{}MinMax", ["HelmMod{}Min", "HelmMod{}Max"]),
-    *make_colgroup(range_1(3), "--ShieldMod{}MinMax", ["ShieldMod{}Min", "ShieldMod{}Max"]),
+    *make_colgroup(range_1(3), "__WeaponMod{}", {"prop": "WeaponMod{}Code", "param": "WeaponMod{}Param", "min": "WeaponMod{}Min", "max": "WeaponMod{}Max"}),
+    *make_colgroup(range_1(3), "__HelmMod{}", {"prop": "HelmMod{}Code", "param": "HelmMod{}Param", "min": "HelmMod{}Min", "max": "HelmMod{}Max"}),
+    *make_colgroup(range_1(3), "__ShieldMod{}", {"prop": "ShieldMod{}Code", "param": "ShieldMod{}Param", "min": "ShieldMod{}Min", "max": "ShieldMod{}Max"}),
     # Hireling.txt
-    ("--NameFirstAndLast", ("NameFirst", "NameLast")),
-    *make_colgroup(["HP", "Str", "Dex", "AR", "Resist"], "--{}-/Lvl", ["{}", "{}/Lvl"]),
-    ("--Defense-/Lvl", ("Defense", "Def/Lvl")),
-    ("--Dmg-MinMax-/Lvl", ("Dmg-Min", "Dmg-Max", "Dmg/Lvl")),
-    *make_colgroup(range_1(6), "--Chance{}-PerLvl", ["Chance{}", "ChancePerLvl{}"]),
-    *make_colgroup(range_1(6), "--Level{}-PerLvl", ["Level{}", "LvlPerLvl{}"]),
+    ("__Name", {"first": "NameFirst", "last": "NameLast"}),
+    *make_colgroup(["HP", "Str", "Dex", "AR", "Resist"], "__{}", {"base": "{}", "/lvl": "{}/Lvl"}),
+    ("__Defense", {"base": "Defense", "/lvl": "Def/Lvl"}),
+    ("__Damage", {"min": "Dmg-Min", "max": "Dmg-Max", "/lvl": "Dmg/Lvl"}),
+    *make_colgroup(
+        range_1(6),
+        "__Skill{}",
+        {"name": "Skill{}", "mode": "Mode{}", "chance": "Chance{}", "chance/lvl": "ChancePerLvl{}", "level": "Level{}", "level/lvl": "LvlPerLvl{}"},
+    ),
     # Inventory.txt
-    *make_colgroup(["Inv", "Grid", "rArm", "Torso"], "--{}LeftRightTopBottom", ["{}Left", "{}Right", "{}Top", "{}Bottom"]),
-    ("--GridXY", ("GridX", "GridY")),
-    ("--GridBoxWidthHeight", ("GridBoxWidth", "GridBoxHeight")),
+    ("__Inv", {"left": "InvLeft", "right": "InvRight", "top": "InvTop", "bottom": "InvBottom"}),
+    ("__Grid", {"left": "GridLeft", "right": "GridRight", "top": "GridTop", "bottom": "GridBottom", "x": "GridX", "y": "GridY"}),
+    ("__GridBox", {"width": "GridBoxWidth", "height": "GridBoxHeight"}),
+    *make_colgroup(
+        ("Inv", "rArm", "Torso", "lArm", "Head", "Neck", "rHand", "lHand", "Belt", "Feet", "Gloves"),
+        "__{}",
+        {"left": "{}Left", "right": "{}Right", "top": "{}Top", "bottom": "{}Bottom", "width": "{}Width", "height": "{}Height"},
+    ),
     *make_colgroup(
         ["rArm", "Torso", "lArm", "Head", "Neck", "rHand", "lHand", "Belt", "Feet", "Gloves"],
         "--{}LeftRightTopBottomWidthHeight",
@@ -567,15 +529,15 @@ COLUMN_GROUPS = initialize_column_groups(
     # LvlPrest.txt
     # ("--SizeXY", ("SizeX", "SizeY")),  # Also in Levels.txt
     # Missiles.txt
-    ("--pSrvCltDoFunc", ("pSrvDoFunc", "pCltDoFunc")),
-    ("--pSrvCltHitFunc", ("pSrvHitFunc", "pCltHitFunc")),
-    *make_colgroup(range_1(3), "--SrvCltSubMissile{}", ["SubMissile{}", "CltSubMissile{}"]),
-    *make_colgroup(range_1(4), "--SrvCltHitSubMissile{}", ["HitSubMissile{}", "CltHitSubMissile{}"]),
-    *make_colgroup(range_1(5), "--ParamAndDesc{}", ["Param{}", "*param{} desc"]),
-    *make_colgroup(range_1(5), "--CltParamAndDesc{}", ["CltParam{}", "*client param{} desc"]),
-    *make_colgroup(range_1(3), "--sHitParAndDesc{}", ["sHitPar{}", "*server hit param{} desc"]),
-    *make_colgroup(range_1(3), "--cHitParAndDesc{}", ["cHitPar{}", "*client hit param{} desc"]),
-    *make_colgroup(range_1(2), "--dParamAndDesc{}", ["dParam{}", "*damage param{} desc"]),
+    ("__pDoFunc", {"srv": "pSrvDoFunc", "clt": "pCltDoFunc"}),
+    ("__pHitFunc", {"srv": "pSrvHitFunc", "clt": "pCltHitFunc"}),
+    *make_colgroup(range_1(3), "__SubMissile{}", {"srv": "SubMissile{}", "clt": "CltSubMissile{}"}),
+    *make_colgroup(range_1(4), "__HitSubMissile{}", {"srv": "HitSubMissile{}", "clt": "CltHitSubMissile{}"}),
+    *make_colgroup(range_1(5), "__Param{}", {"param": "Param{}", "desc": "*param{} desc"}),
+    *make_colgroup(range_1(5), "__CltParam{}", {"clt": "CltParam{}", "desc": "*client param{} desc"}),
+    *make_colgroup(range_1(3), "__SrvHitParam{}", {"param": "sHitPar{}", "desc": "*server hit param{} desc"}),
+    *make_colgroup(range_1(3), "__CltHitParam{}", {"param": "cHitPar{}", "desc": "*client hit param{} desc"}),
+    *make_colgroup(range_1(2), "__DamageParam{}", {"param": "dParam{}", "desc": "*damage param{} desc"}),
     ("--MinDamage0-5", ("MinDamage", "MinLevDam1", "MinLevDam2", "MinLevDam3", "MinLevDam4", "MinLevDam5")),
     ("--MaxDamage0-5", ("MaxDamage", "MaxLevDam1", "MaxLevDam2", "MaxLevDam3", "MaxLevDam4", "MaxLevDam5")),
     ("--MinE0-5", ("EMin", "MinELev1", "MinELev2", "MinELev3", "MinELev4", "MinELev5")),
@@ -587,17 +549,50 @@ COLUMN_GROUPS = initialize_column_groups(
     *make_colgroup(range_1(6), "--MinMax{} (N)", ["Min{} (N)", "Max{} (N)"]),
     *make_colgroup(range_1(6), "--MinMax{} (H)", ["Min{} (H)", "Max{} (H)"]),
     # MonStats.txt
-    ("--MinMaxGrp", ("MinGrp", "MaxGrp")),
-    *make_colgroup(_DIFFICULTY_BASED_COLUMNS, "--{}-RNH", ["{}", "{}(N)", "{}(H)"]),
+    ("__Spawn", {"place": "PlaceSpawn", "x": "SpawnX", "y": "SpawnY", "mode": "SpawnMode"}),
+    ("__Party", {"min": "PartyMin", "max": "PartyMax"}),
+    ("__Grp", {"min": "MinGrp", "max": "MaxGrp"}),
+    *make_colgroup(["Level", "Drain", "ColdEffect", "ToBlock", "AC", "Exp"], "--{}-RNH", ["{}", "{}(N)", "{}(H)"]),
+    ("__AI_R", {"delay": "AIDel", "dist": "AIDist", **{f"p{i}": f"aip{i}" for i in range_1(8)}}),
+    ("__AI_N", {"delay": "AIDel(N)", "dist": "AIDist(N)", **{f"p{i}": f"aip{i}(N)" for i in range_1(8)}}),
+    ("__AI_H", {"delay": "AIDel(H)", "dist": "AIDist(H)", **{f"p{i}": f"aip{i}(H)" for i in range_1(8)}}),
+    *make_colgroup(range_1(8), "__Skill{}", {"name": "Skill{}", "mode": "Sk{}Mode", "level": "Sk{}Lvl"}),
+    ("__Res_R", {"phys": "ResDm", "mag": "ResMa", "fire": "ResFi", "ltng": "ResLi", "cold": "ResCo", "pois": "ResPo"}),
+    ("__Res_N", {"phys": "ResDm(N)", "mag": "ResMa(N)", "fire": "ResFi(N)", "ltng": "ResLi(N)", "cold": "ResCo(N)", "pois": "ResPo(N)"}),
+    ("__Res_H", {"phys": "ResDm(H)", "mag": "ResMa(H)", "fire": "ResFi(H)", "ltng": "ResLi(H)", "cold": "ResCo(H)", "pois": "ResPo(H)"}),
+    ("__HP_R", {"min": "MinHP", "max": "MaxHP"}),
+    ("__HP_N", {"min": "MinHP(N)", "max": "MaxHP(N)"}),
+    ("__HP_H", {"min": "MinHP(H)", "max": "MaxHP(H)"}),
+    *make_colgroup(["A1", "A2", "S1"], "__{}_R", {"MinD": "{}MinD", "MaxD": "{}MaxD", "TH": "{}TH"}),
+    *make_colgroup(["A1", "A2", "S1"], "__{}_N", {"MinD": "{}MinD(N)", "MaxD": "{}MaxD(N)", "TH": "{}TH(N)"}),
+    *make_colgroup(["A1", "A2", "S1"], "__{}_H", {"MinD": "{}MinD(H)", "MaxD": "{}MaxD(H)", "TH": "{}TH(H)"}),
+    *make_colgroup(range_1(3), "__El{}", {"mode": "El{}Mode", "type": "El{}Type"}),
+    *make_colgroup(range_1(3), "__El{}_R", {"Pct": "El{}Pct", "MinD": "El{}MinD", "MaxD": "El{}MaxD", "Dur": "El{}Dur"}),
+    *make_colgroup(range_1(3), "__El{}_N", {"Pct": "El{}Pct(N)", "MinD": "El{}MinD(N)", "MaxD": "El{}MaxD(N)", "Dur": "El{}Dur(N)"}),
+    *make_colgroup(range_1(3), "__El{}_H", {"Pct": "El{}Pct(H)", "MinD": "El{}MinD(H)", "MaxD": "El{}MaxD(H)", "Dur": "El{}Dur(H)"}),
+    ("--TreasureClass-R", [f"TreasureClass{i}" for i in range_1(4)]),
+    ("--TreasureClass-N", [f"TreasureClass{i}(N)" for i in range_1(4)]),
+    ("--TreasureClass-H", [f"TreasureClass{i}(H)" for i in range_1(4)]),
     # MonStats2.txt
     # ("--SizeXY", ("SizeX", "SizeY")),  # Also in Levels.txt
     ("--Light-RGB", ("Light-R", "Light-G", "Light-B")),
     ("--uTrans-RNH", ("uTrans", "uTrans(N)", "uTrans(H)")),
-    ("--htTopLeftWidthHeight", ("htTop", "htLeft", "htWidth", "htHeight")),
+    *make_colgroup(("HD", "TR", "LG", "RA", "LA", "RH", "SH"), "__{}", {"on": "{}", "v": "{}v"}),
+    *make_colgroup(("DT", "NU", "WL", "GH", "BL", "DD", "KB", "SQ", "RN"), "__{}", {"m": "m{}", "d": "d{}"}),
+    *make_colgroup(("A1", "A2", "SC", "S3", "S4"), "__{}", {"m": "m{}", "d": "d{}", "mv": "{}mv"}),
+    *make_colgroup(("S1", "S2"), "__{}", {"on": "{}", "v": "{}v", "m": "m{}", "d": "d{}", "mv": "{}mv"}),
+    ("__ht", {"left": "Left", "top": "Top", "width": "Width", "height": "Height"}),
     # Objects.txt
-    *make_colgroup(["Size", "nTgtF", "nTgtB"], "--{}XY", ["{}X", "{}Y"]),
+    ("__nTgt", {"fx": "nTgtFX", "fy": "nTgtFY", "bx": "nTgtBX", "by": "nTgtBY"}),
     *make_colgroup(["Offset", "Space"], "--XY{}", ["X{}", "Y{}"]),
-    ("--LeftTopWidthHeight", ("Left", "Top", "Width", "Height")),
+    *make_colgroup(
+        ("Selectable", "FrameCnt", "FrameDelta", "CycleAnim", "Lit", "BlocksLight", "HasCollision", "Start", "OrderFlag", "Mode", "Parm"),
+        "__{}",
+        {mode: f"{{}}{index}" for index, mode in enumerate(["NU", "OP", "ON", "S1", "S2", "S3", "S4", "S5"])},
+    ),
+    ("__Selectable", {"NU": "Selectable0", "OP": "Selectable1"}),
+    ("__FrameCnt", {"NU": "FrameCnt0", "OP": "FrameCnt1"}),
+    ("__Box", {"left": "Left", "top": "Top", "width": "Width", "height": "Height"}),
     # Overlay.txt
     # ("--XYOffset", ("xOffset", "yOffset")),  # Also in Objects.txt
     # ("--RedGreenBlue", ("Red", "Green", "Blue")),  # Also in Missiles.txt
@@ -605,44 +600,44 @@ COLUMN_GROUPS = initialize_column_groups(
     ("--IType1-6", tuple(f"IType{i}" for i in range_1(6))),
     # ("--EType1-3", tuple(f"IType{i}" for i in range_1(3))),  # Also in AutoMagic.txt
     ("--Rune1-6", tuple(f"Rune{i}" for i in range_1(6))),
-    *make_colgroup(range_1(6), "--T1MinMax{}", ["T1Min{}", "T1Max{}"]),
+    *make_colgroup(range_1(7), "__T1_{}", {"prop": "T1Code{}", "param": "T1Param{}", "min": "T1Min{}", "max": "T1Max{}"}),
     # Sets.txt
-    *make_colgroup(range(1, 6), "--pMinMax{}A", ["pMin{}A", "pMax{}A"]),
-    *make_colgroup(range(1, 6), "--pMinMax{}B", ["pMin{}B", "pMax{}B"]),
-    *make_colgroup(range_1(8), "--fMinMax{}", ["fMin{}", "fMax{}"]),
+    *make_colgroup(range(2, 6), "__P{}A", {"prop": "pCode{}A", "param": "pParam{}A", "min": "pMin{}A", "max": "pMax{}A"}),
+    *make_colgroup(range(2, 6), "__P{}B", {"prop": "pCode{}B", "param": "pParam{}B", "min": "pMin{}B", "max": "pMax{}B"}),
+    *make_colgroup(range_1(8), "__F{}", {"prop": "fCode{}", "param": "fParam{}", "min": "fMin{}", "max": "fMax{}"}),
     # SetItems.txt
-    *make_colgroup(range_1(9), "--MinMax{}", ["Min{}", "Max{}"]),
-    *make_colgroup(range_1(5), "--aMinMaxA{}", ["aMin{}A", "aMax{}A"]),
-    *make_colgroup(range_1(5), "--aMinMaxB{}", ["aMin{}A", "aMax{}B"]),
+    # *make_colgroup(range_1(9), "__Prop{}", {"prop": "Prop{}", "param": "Par{}", "min": "Min{}", "max": "Max{}"}),  # Also in UniqueItems.txt
+    *make_colgroup(range_1(5), "__aProp{}A", {"prop": "aProp{}A", "param": "aPar{}A", "min": "aMin{}A", "max": "aMax{}A"}),
+    *make_colgroup(range_1(5), "__aProp{}B", {"prop": "aProp{}B", "param": "aPar{}B", "min": "aMin{}B", "max": "aMax{}B"}),
     # Skills.txt
-    ("--SrvCltStFunc", ("SrvStFunc", "CltStFunc")),
-    ("--SrvCltDoFunc", ("SrvDoFunc", "CltDoFunc")),
-    ("--SrvCltMissile", ("SrvMissile", "CltMissile")),
-    *make_colgroup(["", "A", "B", "C"], "--SrvCltMissile{}", ["SrvMissile{}", "CltMissile{}"]),
-    *make_colgroup(range_1(6), "--AuraStatAndCalc{}", ["AuraStat{}", "AuraStatCalc{}"]),
-    *make_colgroup(range_1(6), "--PassiveStatAndCalc{}", ["PassiveStat{}", "PassiveCalc{}"]),
-    *make_colgroup(range_1(3), "--AuraEventAndFunc{}", ["AuraEvent{}", "AuraEventFunc{}"]),
-    ("--AuraTgtEventAndFunc", ("AuraTgtEvent", "AuraTgtEventFunc")),
-    ("--PassiveEventAndFunc", ("PassiveEvent", "PassiveEventFunc")),
-    *make_colgroup(range_1(8), "--ParamAndDescription{}", ["Param{}", "*Param{} Description"]),
+    ("__StartFunc", {"srv": "SrvStFunc", "clt": "CltStFunc"}),
+    ("__DoFunc", {"srv": "SrvDoFunc", "clt": "CltDoFunc"}),
+    *make_colgroup(["", "A", "B", "C"], "__Missile{}", {"srv": "SrvMissile{}", "clt": "CltMissile{}"}),
+    ("__MissileD", {"clt": "CltMissileD"}),  # No matching server-side missile field, but added for consistency's sake
+    *make_colgroup(range_1(6), "__AuraStat{}", {"stat": "AuraStat{}", "calc": "AuraStatCalc{}"}),
+    *make_colgroup(range_1(6), "__PassiveStat{}", {"stat": "PassiveStat{}", "calc": "PassiveCalc{}"}),
+    *make_colgroup(range_1(3), "__AuraEvent{}", {"event": "AuraEvent{}", "func": "AuraEventFunc{}"}),
+    ("__AuraTargetEvent", {"event": "AuraTgtEvent", "func": "AuraTgtEventFunc"}),
+    ("__PassiveEvent", {"event": "PassiveEvent", "func": "PassiveEventFunc"}),
+    *make_colgroup(range_1(8), "__Param{}", {"param": "Param{}", "desc": "*Param{} Description"}),
     ("--MinDam0-5", ("MinDam", "MinLevDam1", "MinLevDam2", "MinLevDam3", "MinLevDam4", "MinLevDam5")),
     ("--MaxDam0-5", ("MaxDam", "MaxLevDam1", "MaxLevDam2", "MaxLevDam3", "MaxLevDam4", "MaxLevDam5")),
     ("--EMin0-5", ("EMin", "EMinLev1", "EMinLev2", "EMinLev3", "EMinLev4", "EMinLev5")),
     ("--EMax0-5", ("EMax", "EMaxLev1", "EMaxLev2", "EMaxLev3", "EMaxLev4", "EMaxLev5")),
     # ("--ELen0-3", ("ELen", "ELevLen1", "ELevLen2", "ELevLen3")),  # Also in Skills.txt
-    ("--CostMultAdd", ("cost mult", "cost add")),
+    ("__Cost", {"multiply": "cost mult", "add": "cost add"}),
     # SkillDesc.txt
-    ("--SkillPageRowColumn", ("SkillPage", "SkillRow", "SkillColumn")),
+    ("__SkillPage", {"page": "SkillPage", "row": "SkillRow", "column": "SkillColumn"}),
     # States.txt
     # ("--Light-RGB", ("Light-R", "Light-G", "Light-B")),  # Also in MonStats2.txt
     # SuperUniques.txt
     # ("--MinMaxGrp", ("MinGrp", "MaxGrp")),  # Also in MonStats.txt
     # ("--uTrans-RNH", ("uTrans", "uTrans(N)", "uTrans(H)")),  # Also in MonStats2.txt
     # TreasureClassEx.txt
-    *make_colgroup(range_1(10), "--ProbAndItem{}", ["Prob{}", "Item{}"]),
+    *make_colgroup(range_1(10), "__Item{}", {"code": "Item{}", "prob": "Prob{}"}),
     # UniqueItems.txt
-    *make_colgroup(range_1(12), "--MinMax{}", ["Min{}", "Max{}"]),
-    # ("--CostMultAdd", ("cost mult", "cost add")),  # Also in Skills.txt
+    *make_colgroup(range_1(12), "__Prop{}", {"prop": "Prop{}", "param": "Par{}", "min": "Min{}", "max": "Max{}"}),
+    # ("__Cost", {"multiply": "cost mult", "add": "cost add"}),  # Also in Skills.txt
 )
 # fmt: on
 # pylint: enable=line-too-long

--- a/d2txt.py
+++ b/d2txt.py
@@ -4,6 +4,7 @@
 from argparse import ArgumentParser
 import collections.abc
 import csv
+import enum
 from itertools import islice
 from itertools import zip_longest
 from os import PathLike
@@ -348,6 +349,14 @@ def encode_aurafilter(flags: List[str]) -> int:
     return aurafilter
 
 
+@enum.unique
+class ColumnGroupType(enum.Enum):
+    """Represents how the column group should be represented in TOML."""
+
+    ARRAY = enum.auto()
+    TABLE = enum.auto()
+
+
 def range_1(stop: int) -> range:
     """Returns a range that starts at 1 and ends at `stop`, inclusive."""
     return range(1, stop + 1)
@@ -356,6 +365,7 @@ def range_1(stop: int) -> range:
 class ColumnGroupDefinition(NamedTuple):
     """Defines a column group."""
 
+    type: ColumnGroupType
     alias: str
     members: Tuple[str, ...]
 
@@ -386,7 +396,9 @@ def initialize_column_groups(
         # Rely on preservation of insertion order of dicts Python 3.6+ to ensure
         # that column groups with equal member count maintain the same order.
         dict.fromkeys(
-            ColumnGroupDefinition(alias=alias, members=tuple(members))
+            ColumnGroupDefinition(
+                type=ColumnGroupType.ARRAY, alias=alias, members=tuple(members)
+            )
             for alias, members in colgroups
         ),
         key=lambda colgroup: len(colgroup.members),

--- a/d2txt.py
+++ b/d2txt.py
@@ -379,11 +379,13 @@ def initialize_column_groups(
         colgroups: Tuples of the form (group alias, sequence of member columns).
 
     Returns:
-        List of column group definitions.
+        List of unique column group definitions.
         The list is sorted by # of member columns, from greatest to least.
     """
     return sorted(
-        (
+        # Rely on preservation of insertion order of dicts Python 3.6+ to ensure
+        # that column groups with equal member count maintain the same order.
+        dict.fromkeys(
             ColumnGroupDefinition(alias=alias, members=tuple(members))
             for alias, members in colgroups
         ),

--- a/d2txt.py
+++ b/d2txt.py
@@ -381,13 +381,19 @@ class ColumnGroupDefinition(NamedTuple):
 
 
 def make_colgroup(
-    params: Iterable[Union[int, str]], colgroup: str, columns: Iterable[str]
-) -> List[Tuple[str, Tuple[str, ...]]]:
+    params: Iterable[Union[int, str]],
+    colgroup: str,
+    columns: Union[Iterable[str], Mapping[str, str]],
+) -> Iterator[Tuple[str, Union[Tuple[str, ...], Dict[str, str]]]]:
     """Generates column groups by using formatting parameters."""
-    return [
-        (colgroup.format(param), tuple(col.format(param) for col in columns))
-        for param in params
-    ]
+    if isinstance(columns, collections.abc.Mapping):
+        return (
+            (colgroup.format(p), {k.format(p): v.format(p) for k, v in columns.items()})
+            for p in params
+        )
+    return (
+        (colgroup.format(p), tuple(col.format(p) for col in columns)) for p in params
+    )
 
 
 def initialize_column_groups(

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -113,12 +113,12 @@ class TestD2TXTColumnGroups(TestD2TXTBase):
 
     def test_alias_format(self):
         """Tests if column group aliases have consistent names."""
-        for alias in COLUMN_GROUPS:
+        for alias, _ in COLUMN_GROUPS:
             self.assertRegex(alias, r"^--\w")
 
     def test_column_group_non_empty(self):
         """Tests if column groups have at least two member columns."""
-        for alias, members in COLUMN_GROUPS.items():
+        for alias, members in COLUMN_GROUPS:
             self.assertGreaterEqual(
                 len(members),
                 2,
@@ -127,7 +127,7 @@ class TestD2TXTColumnGroups(TestD2TXTBase):
 
     def test_column_group_sorted(self):
         """Tests if column groups are properly sorted by # of member columns."""
-        aliases = iter(COLUMN_GROUPS.items())
+        aliases = iter(COLUMN_GROUPS)
         alias1, members1 = next(aliases)
         for alias2, members2 in aliases:
             self.assertGreaterEqual(

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -113,26 +113,26 @@ class TestD2TXTColumnGroups(TestD2TXTBase):
 
     def test_alias_format(self):
         """Tests if column group aliases have consistent names."""
-        for alias, _ in COLUMN_GROUPS:
-            self.assertRegex(alias, r"^--\w")
+        for group in COLUMN_GROUPS:
+            self.assertRegex(group.alias, r"^--\w")
 
     def test_column_group_non_empty(self):
         """Tests if column groups have at least two member columns."""
-        for alias, members in COLUMN_GROUPS:
+        for group in COLUMN_GROUPS:
             self.assertGreaterEqual(
-                len(members),
+                len(group.members),
                 2,
-                f"Column group {alias!r} does not have enough member columns",
+                f"Column group {group!r} does not have enough member columns",
             )
 
     def test_column_group_sorted(self):
         """Tests if column groups are properly sorted by # of member columns."""
-        aliases = iter(COLUMN_GROUPS)
-        alias1, members1 = next(aliases)
-        for alias2, members2 in aliases:
+        groups = iter(COLUMN_GROUPS)
+        group1 = next(groups)
+        for group2 in groups:
             self.assertGreaterEqual(
-                len(members1),
-                len(members2),
-                f"Column group {alias1!r} appears before {alias2!r}.",
+                len(group1.members),
+                len(group2.members),
+                f"Column group {group1!r} appears before {group2!r}.",
             )
-            alias1, members1 = alias2, members2
+            group2 = group1

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -126,6 +126,9 @@ class TestD2TXTColumnGroups(TestD2TXTBase):
     def test_column_group_non_empty(self):
         """Tests if column groups have at least two member columns."""
         for group in COLUMN_GROUPS:
+            # Make an exception for CltMissileD in Skills.txt
+            if group.alias == "__MissileD":
+                continue
             self.assertGreaterEqual(
                 len(group.members),
                 2,

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Unit test for conversion to and from TOML."""
 
+from collections import Counter
 import os
 from tempfile import NamedTemporaryFile
 import unittest
@@ -136,3 +137,10 @@ class TestD2TXTColumnGroups(TestD2TXTBase):
                 f"Column group {group1!r} appears before {group2!r}.",
             )
             group2 = group1
+
+    def test_column_group_unique(self):
+        """Tests if column group entries are unique."""
+        group_counter = Counter(COLUMN_GROUPS)
+        group_counter.subtract(set(COLUMN_GROUPS))
+        duplicates = list(group_counter.elements())
+        self.assertEqual(len(duplicates), 0, f"Duplicates are {duplicates!r}")

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -6,6 +6,7 @@ import os
 from tempfile import NamedTemporaryFile
 import unittest
 
+from d2txt import ColumnGroupType
 from d2txt import COLUMN_GROUPS
 from d2txt import D2TXT
 from d2txt import d2txt_to_toml
@@ -137,6 +138,32 @@ class TestD2TXTColumnGroups(TestD2TXTBase):
                 f"Column group {group1!r} appears before {group2!r}.",
             )
             group2 = group1
+
+    def test_column_group_unique_columns(self):
+        """Tests if column groups do not have duplicate member columns."""
+        for colgroup in COLUMN_GROUPS:
+            with self.subTest(colgroup=colgroup):
+                group_type, _, members = colgroup
+
+                if group_type == ColumnGroupType.ARRAY:
+                    self.assertEqual(
+                        len(members),
+                        len(set(members)),
+                        "Array member columns must be unique",
+                    )
+                elif group_type == ColumnGroupType.TABLE:
+                    self.assertEqual(
+                        len(members),
+                        len(set(m[0] for m in members)),
+                        "Table member aliases must be unique",
+                    )
+                    self.assertEqual(
+                        len(members),
+                        len(set(m[1] for m in members)),
+                        "Table member columns must be unique",
+                    )
+                else:
+                    self.fail(f"Unexpected group type {group_type!r}")
 
     def test_column_group_unique(self):
         """Tests if column group entries are unique."""

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -116,7 +116,12 @@ class TestD2TXTColumnGroups(TestD2TXTBase):
     def test_alias_format(self):
         """Tests if column group aliases have consistent names."""
         for group in COLUMN_GROUPS:
-            self.assertRegex(group.alias, r"^--\w")
+            if group.type == ColumnGroupType.ARRAY:
+                self.assertRegex(group.alias, r"^--\w")
+            elif group.type == ColumnGroupType.TABLE:
+                self.assertRegex(group.alias, r"^__\w")
+            else:
+                self.fail(f"Unexpected group type {group.type!r}")
 
     def test_column_group_non_empty(self):
         """Tests if column groups have at least two member columns."""


### PR DESCRIPTION
Supports generating TOML inline tables for heterogeneous column groups.

Add several new table colgroups, and convert many array colgroups to table colgroups.

Close #15