### PR TITLE
Fix broken duplicate column checker & duplicate columns

### DIFF
--- a/d2txt.py
+++ b/d2txt.py
@@ -506,11 +506,6 @@ COLUMN_GROUPS = initialize_column_groups(
         "__{}",
         {"left": "{}Left", "right": "{}Right", "top": "{}Top", "bottom": "{}Bottom", "width": "{}Width", "height": "{}Height"},
     ),
-    *make_colgroup(
-        ["rArm", "Torso", "lArm", "Head", "Neck", "rHand", "lHand", "Belt", "Feet", "Gloves"],
-        "--{}LeftRightTopBottomWidthHeight",
-        ["{}Left", "{}Right", "{}Top", "{}Bottom", "{}Width", "{}Height"]
-    ),
     # ItemTypes.txt
     ("--BodyLoc1-2", ("BodyLoc1", "BodyLoc2")),
     ("--MaxSock1-25-40", ("MaxSock1", "MaxSock25", "MaxSock40")),
@@ -581,7 +576,7 @@ COLUMN_GROUPS = initialize_column_groups(
     *make_colgroup(("DT", "NU", "WL", "GH", "BL", "DD", "KB", "SQ", "RN"), "__{}", {"m": "m{}", "d": "d{}"}),
     *make_colgroup(("A1", "A2", "SC", "S3", "S4"), "__{}", {"m": "m{}", "d": "d{}", "mv": "{}mv"}),
     *make_colgroup(("S1", "S2"), "__{}", {"on": "{}", "v": "{}v", "m": "m{}", "d": "d{}", "mv": "{}mv"}),
-    ("__ht", {"left": "Left", "top": "Top", "width": "Width", "height": "Height"}),
+    ("__ht", {"left": "htLeft", "top": "htTop", "width": "htWidth", "height": "htHeight"}),
     # Objects.txt
     ("__nTgt", {"fx": "nTgtFX", "fy": "nTgtFY", "bx": "nTgtBX", "by": "nTgtBY"}),
     *make_colgroup(["Offset", "Space"], "--XY{}", ["X{}", "Y{}"]),

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 """Unit test for conversion to and from TOML."""
 
-from collections import Counter
 import os
 from tempfile import NamedTemporaryFile
 import unittest
@@ -174,8 +173,17 @@ class TestD2TXTColumnGroups(TestD2TXTBase):
                     self.fail(f"Unexpected group type {group_type!r}")
 
     def test_column_group_unique(self):
-        """Tests if column group entries are unique."""
-        group_counter = Counter(COLUMN_GROUPS)
-        group_counter.subtract(set(COLUMN_GROUPS))
-        duplicates = list(group_counter.elements())
-        self.assertEqual(len(duplicates), 0, f"Duplicates are {duplicates!r}")
+        """Tests if column group definitions have unique sets of column names."""
+        self.longMessage = False  # pylint:disable=invalid-name
+        member_columns_seen = {}
+        for colgroup in COLUMN_GROUPS:
+            with self.subTest(colgroup=colgroup):
+                member_columns_cf = frozenset(
+                    map(str.casefold, colgroup.member_names())
+                )
+                self.assertNotIn(
+                    member_columns_cf,
+                    member_columns_seen,
+                    f"Is shadowed by {member_columns_seen.get(member_columns_cf)!r}",
+                )
+                member_columns_seen[member_columns_cf] = colgroup


### PR DESCRIPTION
Fix the broken unit test that checks for duplicate columns in column group definitions. Now the test properly checks if two column group definitions share the exact same set of casefolded member column names.

Fixing the test also revealed hidden bugs in the current set of column group definitions:

* The `__ht` column group for MonStats2.txt was incorrectly defined (due to bad copy-pasting). It overlapped with the `__Box` column group for Objects.txt. This prevented grouping the columns in MonStats2.txt, while grouping the columns in Objects.txt to be grouped under the incorrect alias.
* Column group definitions for equipment slot config in Inventory.txt were duplicated--when I converted array column groups to table column groups, I forgot to remove the original.

These issues have been fixed. It changes the behavior, though, and deserves a version bump.