### PR TITLE
chore: Update dependencies 2020-07-13

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -4,8 +4,8 @@ flit==2.3.0
   flit-core==2.3.0
     pytoml==0.1.21
   pytoml==0.1.21
-  requests==2.23.0
-    certifi==2020.4.5.1
+  requests==2.24.0
+    certifi==2020.6.20
     chardet==3.0.4
-    idna==2.9
+    idna==2.10
     urllib3==1.25.9

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,4 @@
 -r requirements-lint.txt
 -r requirements-test.txt
 -r requirements.txt
-pipdeptree==0.13.2
+pipdeptree==1.0.0

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -4,7 +4,7 @@ black==19.10b0
   attrs==19.3.0
   click==7.1.2
   pathspec==0.8.0
-  regex==2020.5.14
+  regex==2020.6.8
   toml==0.10.1
   typed-ast==1.4.1
 isort==4.3.21

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -8,8 +8,8 @@ black==19.10b0
   toml==0.10.1
   typed-ast==1.4.1
 isort==4.3.21
-pylint==2.5.2
-  astroid==2.4.1
+pylint==2.5.3
+  astroid==2.4.2
     lazy-object-proxy==1.4.3
     six==1.15.0
     wrapt==1.12.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,16 +1,16 @@
 # Dependencies for testing
-tox==3.15.1
+tox==3.16.1
   colorama==0.4.3
   filelock==3.0.12
   packaging==20.4
     pyparsing==2.4.7
     six==1.15.0
   pluggy==0.13.1
-  py==1.8.1
+  py==1.9.0
   six==1.15.0
   toml==0.10.1
-  virtualenv==20.0.21
+  virtualenv==20.0.26
     appdirs==1.4.4
-    distlib==0.3.0
+    distlib==0.3.1
     filelock==3.0.12
     six==1.15.0


### PR DESCRIPTION
Development-related packages

* Update pipdeptree to 1.0.0
* Update Pylint to 2.5.3
    * Note: Pylint 2.5.3 does not support isort 5 yet. Pylint is planning to add support for isort 5, but as of writing, [the PR](https://github.com/PyCQA/pylint/pull/3725) has not been merged yet.
* Update Tox to 3.16.1
* Update upstream dependencies of Black and Flit