### PR TITLE
chore!: Maintenance 2022-04

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ author = "pastelmind"
 author-email = "keepyourhonor@gmail.com"
 home-page = "https://github.com/pastelmind/d2txt"
 requires = [
-    "qtoml >= 0.3.0, < 1",
+    "qtoml >= 0.3.1, < 1",
     "toml >= 0.10.1, < 1",
 ]
 description-file = "README.md"

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,11 +1,11 @@
 # Dependencies for building
-flit==3.2.0
-  docutils==0.17.1
-  flit-core==3.2.0
-    toml==0.10.2
-  requests==2.25.1
-    certifi==2020.12.5
-    chardet==4.0.0
-    idna==2.10
-    urllib3==1.26.4
-  toml==0.10.2
+flit==3.7.1
+  docutils==0.18.1
+  flit_core==3.7.1
+  requests==2.27.1
+    certifi==2021.10.8
+    charset-normalizer==2.0.12
+    idna==3.3
+    urllib3==1.26.9
+  tomli==2.0.1
+  tomli_w==1.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,4 @@
 -r requirements-lint.txt
 -r requirements-test.txt
 -r requirements.txt
-pipdeptree==2.0.0
+pipdeptree==2.2.1

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,19 +1,17 @@
 # Dependencies for linting source code
-black==20.8b1
-  appdirs==1.4.4
-  click==7.1.2
+black==22.3.0
+  click==8.1.2
   mypy-extensions==0.4.3
-  pathspec==0.8.1
-  regex==2021.4.4
-  toml==0.10.2
-  typed-ast==1.4.3
-  typing-extensions==3.7.4.3
-isort==5.8.0
-pylint==2.7.4
-  astroid==2.5.3
-    lazy-object-proxy==1.6.0
-    wrapt==1.12.1
-  colorama==0.4.4
-  isort==5.8.0
-  mccabe==0.6.1
-  toml==0.10.2
+  pathspec==0.9.0
+  platformdirs==2.5.1
+  tomli==2.0.1
+isort==5.10.1
+pylint==2.13.5
+  astroid==2.11.2
+    lazy-object-proxy==1.7.1
+    wrapt==1.14.0
+  dill==0.3.4
+  isort==5.10.1
+  mccabe==0.7.0
+  platformdirs==2.5.1
+  tomli==2.0.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 # Dependencies for testing
 tox==3.24.5
-  filelock==3.6.0
+  filelock==3.6.0; python_version >= '3.7'
   packaging==21.3
     pyparsing==3.0.8
   pluggy==1.0.0
@@ -9,6 +9,6 @@ tox==3.24.5
   toml==0.10.2
   virtualenv==20.14.0
     distlib==0.3.4
-    filelock==3.6.0
-    platformdirs==2.5.1
+    filelock==3.6.0; python_version >= '3.7'
+    platformdirs==2.5.1; python_version >= '3.7'
     six==1.16.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,15 +1,14 @@
 # Dependencies for testing
-tox==3.23.0
-  colorama==0.4.4
-  filelock==3.0.12
-  packaging==20.9
-    pyparsing==2.4.7
-  pluggy==0.13.1
-  py==1.10.0
-  six==1.15.0
+tox==3.24.5
+  filelock==3.6.0
+  packaging==21.3
+    pyparsing==3.0.8
+  pluggy==1.0.0
+  py==1.11.0
+  six==1.16.0
   toml==0.10.2
-  virtualenv==20.4.4
-    appdirs==1.4.4
-    distlib==0.3.1
-    filelock==3.0.12
-    six==1.15.0
+  virtualenv==20.14.0
+    distlib==0.3.4
+    filelock==3.6.0
+    platformdirs==2.5.1
+    six==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qtoml==0.3.0
-  attrs==19.3.0
-  click==7.1.2
+qtoml==0.3.1
+  attrs==21.4.0
+  click==8.1.2
 toml==0.10.2

--- a/samples/itype_analyzer.py
+++ b/samples/itype_analyzer.py
@@ -5,8 +5,8 @@
 import argparse
 import sys
 
-import colorama
-from colorama import Fore
+import colorama  # pylint: disable=import-error
+from colorama import Fore  # pylint: disable=import-error
 
 from d2txt import D2TXT
 

--- a/tests/test_d2txt.py
+++ b/tests/test_d2txt.py
@@ -452,7 +452,7 @@ class TestD2TXTSaveFile(unittest.TestCase):
 
         d2txt.to_txt(type(self).save_txt_path)
         # newline='' is required to make csv.writer work correctly
-        with open(type(self).save_txt_path, newline="") as save_txt:
+        with open(type(self).save_txt_path, newline="", encoding="utf-8") as save_txt:
             saved_contents = save_txt.read()
 
         self.assertEqual(


### PR DESCRIPTION
- Bump required qtoml version to 0.3.1
- Update dependencies
- Also takes care of https://github.com/advisories/GHSA-q2q7-5pp4-w6pg
  (This only affects our dev dependencies, so no worries for users)